### PR TITLE
Add execution options

### DIFF
--- a/jupyter_nbmodel_client/client.py
+++ b/jupyter_nbmodel_client/client.py
@@ -150,7 +150,7 @@ class NbModelClient(NotebookModel):
 
         self._log.debug("Waiting for model synchronization…")
         self.__synced.wait(REQUEST_TIMEOUT)
-        if self.synced:
+        if not self.synced:
             self._log.warning("Document %s not yet synced.", self._path)
 
     def stop(self) -> None:


### PR DESCRIPTION
Add cell execution options in `NbModelClient.execute_cell`:
silent, store_history, stop_on_error and timeout

Fix warning on document synchronisation

