### PR TITLE
Revert "Use multithreading flag"

### DIFF
--- a/jupyter_nbmodel_client/model.py
+++ b/jupyter_nbmodel_client/model.py
@@ -43,6 +43,8 @@ except ImportError:
         return set()
 
 
+
+
 class KernelClient(t.Protocol):
     """Interface to be implemented by the kernel client."""
 
@@ -119,9 +121,7 @@ class NotebookModel(MutableSequence):
     # FIXME add API to clear code cell; aka execution count and outputs
 
     def __init__(self) -> None:
-        self._doc: YNotebook
-        # Initialize _doc
-        self._reset_y_model()
+        self._doc = YNotebook()
 
     def __delitem__(self, index: int) -> NotebookNode:
         raw_ycell = self._doc.ycells.pop(index)
@@ -312,6 +312,4 @@ class NotebookModel(MutableSequence):
 
     def _reset_y_model(self) -> None:
         """Reset the Y model."""
-        # Use allow_multithreading=True to ensure blocking document transactions
-        # https://jupyter-server.github.io/pycrdt/usage/#Transactions
-        self._doc = YNotebook(ydoc=pycrdt.Doc(allow_multithreading=True))
+        self._doc = YNotebook()


### PR DESCRIPTION
Reverts datalayer/jupyter-nbmodel-client#14 as it is not solving the panic error of #12 