### PR TITLE
Use a lock to prevent document access or change between threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ dmypy.json
 # OSX files
 .DS_Store
 .jupyter_ystore.db
+.dot-env

--- a/jupyter_nbmodel_client/client.py
+++ b/jupyter_nbmodel_client/client.py
@@ -141,7 +141,8 @@ class NbModelClient(NotebookModel):
             emsg = f"Unable to open a websocket connection to {self._server_url} within {self._timeout} s."
             raise TimeoutError(emsg)
 
-        sync_message = create_sync_message(self._doc.ydoc)
+        with self._lock:
+            sync_message = create_sync_message(self._doc.ydoc)
         self._log.debug(
             "Sending SYNC_STEP1 message for document %s",
             self._path,
@@ -201,7 +202,8 @@ class NbModelClient(NotebookModel):
                 YSyncMessageType(message[1]).name,
                 self._path,
             )
-            reply = handle_sync_message(message[1:], self._doc.ydoc)
+            with self._lock:
+                reply = handle_sync_message(message[1:], self._doc.ydoc)
             if message[1] == YSyncMessageType.SYNC_STEP2:
                 self.__synced.set()
             if reply is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = ["jupyter_ydoc>=2.1.2,<4.0.0", "nbformat~=5.0", "pycrdt >=0.10.3,
 
 [project.optional-dependencies]
 test = ["ipykernel", "jupyter-kernel-client", "jupyter-server-ydoc~=1.0.0", "pytest>=7.0", "pytest-timeout"]
-lint = ["mdformat>0.7", "mdformat-gfm>=0.3.5", "ruff"]
+lint = ["pre_commit", "mdformat>0.7", "mdformat-gfm>=0.3.5", "ruff"]
 typing = ["mypy>=0.990"]
 
 [project.license]


### PR DESCRIPTION
This can happen if a document change is happening while another one is still in process because Yrs transaction are not thread safe.

Fixes #12