### PR TITLE
Switch to async for notebook client

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ pip install jupyter_nbmodel_client
 > [!WARNING]
 > This package requires temporary a dev version of pycrdt. Therefore you will need
 > to install a Rust compiler to install it.
+> Once down, execute `pip install maturin[patchelf]` and then `pip install "pycrdt@git+https://github.com/fcollonval/pycrdt.git@dev"`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ to communicate between user clients and the ai agent.
                 "username": {
                   "title": "Unique identifier of the user making the prompt.",
                   "type": "string"
+                },
+                "timestamp": {
+                  "title": "Number of milliseconds elapsed since the epoch; i.e. January 1st, 1970 at midnight UTC.",
+                  "type": "integer"
                 }
               },
               "required": ["id", "prompt"]
@@ -204,6 +208,10 @@ to communicate between user clients and the ai agent.
                 "type": {
                   "title": "Type message",
                   "enum": [0, 1, 2]
+                },
+                "timestamp": {
+                  "title": "Number of milliseconds elapsed since the epoch; i.e. January 1st, 1970 at midnight UTC.",
+                  "type": "integer"
                 }
               },
               "required": ["id", "prompt"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ To install the library, run the following command.
 pip install jupyter_nbmodel_client
 ```
 
+> [!WARNING]
+> This package requires temporary a dev version of pycrdt. Therefore you will need
+> to install a Rust compiler to install it.
+
 ## Usage
 
 1. Ensure you have the needed packages in your environment to run the example here after.

--- a/jupyter_nbmodel_client/__init__.py
+++ b/jupyter_nbmodel_client/__init__.py
@@ -6,13 +6,14 @@
 
 from nbformat import NotebookNode
 
-from .agent import BaseNbAgent
+from .agent import AIMessageType, BaseNbAgent
 from .client import NbModelClient, get_jupyter_notebook_websocket_url
 from .model import KernelClient, NotebookModel
 
 __version__ = "0.6.0"
 
 __all__ = [
+    "AIMessageType",
     "BaseNbAgent",
     "KernelClient",
     "NbModelClient",

--- a/jupyter_nbmodel_client/agent.py
+++ b/jupyter_nbmodel_client/agent.py
@@ -97,7 +97,9 @@ class BaseNbAgent(NbModelClient):
         super().__init__(websocket_url, path, username, timeout, log)
         self._doc_events: asyncio.Queue[dict] = asyncio.Queue()
         self._events_worker: asyncio.Task | None = None
-        self._id = uuid4().hex  # ID for doc modification origin
+        self._id = hash(
+            uuid4().hex
+        )  # hashed ID for doc modification origin - as pycrdt 0.10 return hashed origin and hash(hashed) == hashed
 
     async def start(self) -> None:
         await super().start()
@@ -157,9 +159,7 @@ class BaseNbAgent(NbModelClient):
         self._log.debug(
             "Prompt: timestamp [%d] / cell_id [%s] / prompt [%s]",
             timestamp,
-            username,
             cell_id,
-            prompt_id,
             prompt[:20],
         )
 

--- a/jupyter_nbmodel_client/agent.py
+++ b/jupyter_nbmodel_client/agent.py
@@ -469,8 +469,9 @@ class BaseNbAgent(NbModelClient):
             )
             messages.append(message)
             metadata["datalayer"]["ai"]["messages"] = messages
-
-            metadata["datalayer"] = metadata["datalayer"].copy()
+            new_metadata = metadata["datalayer"].copy()
+            self._log.debug("New metadata: [%s].", new_metadata)
+            metadata["datalayer"] = new_metadata
 
         if cell_id:
             cell = self.get_cell(cell_id)

--- a/jupyter_nbmodel_client/agent.py
+++ b/jupyter_nbmodel_client/agent.py
@@ -470,7 +470,7 @@ class BaseNbAgent(NbModelClient):
             messages.append(message)
             metadata["datalayer"]["ai"]["messages"] = messages
             new_metadata = metadata["datalayer"].copy()
-            self._log.debug("New metadata: [%s].", new_metadata)
+            del metadata["datalayer"]  # FIXME upstream - update of key is not possible 😱
             metadata["datalayer"] = new_metadata
 
         if cell_id:

--- a/jupyter_nbmodel_client/agent.py
+++ b/jupyter_nbmodel_client/agent.py
@@ -453,25 +453,23 @@ class BaseNbAgent(NbModelClient):
             "timestamp": timestamp(),
         }
 
-        def set_message(metadata: Map, message: dict):
-            if "datalayer" not in metadata:
-                metadata["datalayer"] = {"ai": {"prompts": [], "messages": []}}
-            elif "ai" not in metadata["datalayer"]:
-                metadata["datalayer"] = {"ai": {"prompts": [], "messages": []}}
-            elif "messages" not in metadata["datalayer"]["ai"]:
-                metadata["datalayer"]["ai"] = {"messages": []}
+        def set_message(metadata: dict, message: dict):
+            dla = metadata.get("datalayer") or {"ai": {"prompts": [], "messages": []}}
+            dlai = dla.get("ai", {"prompts": [], "messages": []})
+            dlmsg = dlai.get("messages", [])
 
             messages = list(
                 filter(
                     lambda m: not m.get("parent_id") or m["parent_id"] != parent_id,
-                    metadata["datalayer"]["ai"]["messages"],
+                    dlmsg,
                 )
             )
             messages.append(message)
-            metadata["datalayer"]["ai"]["messages"] = messages
-            new_metadata = metadata["datalayer"].copy()
-            del metadata["datalayer"]  # FIXME upstream - update of key is not possible 😱
-            metadata["datalayer"] = new_metadata
+            dlai["messages"] = messages
+            dla["ai"] = dlai
+            if "datalayer" in metadata:
+                del metadata["datalayer"]  # FIXME upstream - update of key is not possible 😱
+            metadata["datalayer"] = dla.copy()
 
         if cell_id:
             cell = self.get_cell(cell_id)

--- a/jupyter_nbmodel_client/agent.py
+++ b/jupyter_nbmodel_client/agent.py
@@ -449,7 +449,7 @@ class BaseNbAgent(NbModelClient):
         message_dict = {
             "parent_id": parent_id,
             "message": message,
-            "type": message_type,
+            "type": int(message_type),
             "timestamp": timestamp(),
         }
 

--- a/jupyter_nbmodel_client/agent.py
+++ b/jupyter_nbmodel_client/agent.py
@@ -384,10 +384,12 @@ class BaseNbAgent(NbModelClient):
             if "metadata" not in cell:
                 cell["metadata"] = Map({"datalayer": {"ai": {"prompts": [], "messages": []}}})
             set_message(cell["metadata"], message_dict)
+            self._log.debug("Add ai message in cell [%s] metadata: [%s].", cell_id, message_dict)
 
         else:
             notebook_metadata = self._doc._ymeta["metadata"]
             set_message(notebook_metadata, message_dict)
+            self._log.debug("Add ai message in notebook metadata: [%s].", cell_id, message_dict)
 
     # def notify(self, message: str, cell_id: str = "") -> None:
     #     """Send a transient message to users.

--- a/jupyter_nbmodel_client/client.py
+++ b/jupyter_nbmodel_client/client.py
@@ -172,7 +172,10 @@ class NbModelClient(NotebookModel):
         await self.__websocket.send(sync_message)
 
         self._log.debug("Waiting for model synchronization…")
-        await asyncio.wait_for(self.__synced.wait(), REQUEST_TIMEOUT)
+        try:
+            await asyncio.wait_for(self.__synced.wait(), REQUEST_TIMEOUT)
+        except asyncio.TimeoutError:
+            ...
         if not self.synced:
             self._log.warning("Document %s not yet synced.", self._path)
 

--- a/jupyter_nbmodel_client/client.py
+++ b/jupyter_nbmodel_client/client.py
@@ -25,6 +25,8 @@ from .model import NotebookModel
 from .utils import fetch, url_path_join
 
 default_logger = logging.getLogger("jupyter_nbmodel_client")
+# Default value taken from uvicorn: https://www.uvicorn.org/#command-line-options
+WEBSOCKETS_MAX_BODY_SIZE = os.environ.get("WEBSOCKETS_MAX_BODY_SIZE", 16 * 1024 * 1024)
 
 
 def get_jupyter_notebook_websocket_url(
@@ -102,6 +104,7 @@ class NbModelClient(NotebookModel):
         username: str = os.environ.get("USER", "username"),
         timeout: float = REQUEST_TIMEOUT,
         log: logging.Logger | None = None,
+        ws_max_body_size: int | None = None,
     ) -> None:
         super().__init__()
         self._ws_url = websocket_url
@@ -109,6 +112,7 @@ class NbModelClient(NotebookModel):
         self._username = username
         self._timeout = timeout
         self._log = log or default_logger
+        self._ws_max_body_size = ws_max_body_size or WEBSOCKETS_MAX_BODY_SIZE
 
         self.__synced = asyncio.Event()
         self.__websocket: ClientConnection | None = None
@@ -153,6 +157,7 @@ class NbModelClient(NotebookModel):
             self._ws_url,
             user_agent_header="Jupyter NbModel Client",
             logger=self._log,
+            max_size=self._ws_max_body_size,
         )
 
         # Start listening to incoming message

--- a/jupyter_nbmodel_client/client.py
+++ b/jupyter_nbmodel_client/client.py
@@ -26,6 +26,7 @@ from .utils import fetch, url_path_join
 
 default_logger = logging.getLogger("jupyter_nbmodel_client")
 # Default value taken from uvicorn: https://www.uvicorn.org/#command-line-options
+# Note: the default size for Tornado is 10MB not 16MB
 WEBSOCKETS_MAX_BODY_SIZE = os.environ.get("WEBSOCKETS_MAX_BODY_SIZE", 16 * 1024 * 1024)
 
 

--- a/jupyter_nbmodel_client/client.py
+++ b/jupyter_nbmodel_client/client.py
@@ -27,7 +27,7 @@ from .utils import fetch, url_path_join
 default_logger = logging.getLogger("jupyter_nbmodel_client")
 # Default value taken from uvicorn: https://www.uvicorn.org/#command-line-options
 # Note: the default size for Tornado is 10MB not 16MB
-WEBSOCKETS_MAX_BODY_SIZE = os.environ.get("WEBSOCKETS_MAX_BODY_SIZE", 16 * 1024 * 1024)
+WEBSOCKETS_MAX_BODY_SIZE = int(os.environ.get("WEBSOCKETS_MAX_BODY_SIZE", 16 * 1024 * 1024))
 
 
 def get_jupyter_notebook_websocket_url(

--- a/jupyter_nbmodel_client/tests/conftest.py
+++ b/jupyter_nbmodel_client/tests/conftest.py
@@ -131,7 +131,13 @@ def ws_server(unused_port, monkeypatch):
             sys.executable,
             str(HERE / "_asgi.py"),
         ],
+        stderr=PIPE,
     )
+
+    while True:
+        log = ws_server.stderr.readline()
+        if b"Running on " in log:
+            break
 
     try:
         yield f"ws://localhost:{unused_port}"

--- a/jupyter_nbmodel_client/tests/test_agent.py
+++ b/jupyter_nbmodel_client/tests/test_agent.py
@@ -10,9 +10,9 @@ from unittest.mock import MagicMock
 from jupyter_nbmodel_client import BaseNbAgent, NbModelClient
 
 
-def test_default_content(ws_server):
+async def test_default_content(ws_server):
     room = uuid.uuid4().hex
-    with BaseNbAgent(f"{ws_server}/{room}") as agent:
+    async with BaseNbAgent(f"{ws_server}/{room}") as agent:
         default_content = agent.as_dict()
 
     assert default_content == {"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
@@ -21,8 +21,8 @@ def test_default_content(ws_server):
 async def test_set_user_prompt(ws_server):
     room = uuid.uuid4().hex
     room_url = f"{ws_server}/{room}"
-    with NbModelClient(room_url) as client:
-        with BaseNbAgent(room_url) as agent:
+    async with NbModelClient(room_url) as client:
+        async with BaseNbAgent(room_url) as agent:
             agent._on_user_prompt = MagicMock()
             idx = client.add_code_cell("print('hello')")
             client.set_cell_metadata(
@@ -31,6 +31,7 @@ async def test_set_user_prompt(ws_server):
                 {"ai": {"prompts": [{"id": "12345", "prompt": "Once upon a time"}]}},
             )
 
+            await asyncio.sleep(0.1)
             await asyncio.sleep(0.1)
 
             assert agent.as_dict() == {
@@ -55,15 +56,21 @@ async def test_set_user_prompt(ws_server):
 
             assert agent._on_user_prompt.called
             args, kwargs = agent._on_user_prompt.call_args
-            assert args == (client[idx]["id"], "Once upon a time")
-            assert kwargs == {}
+            assert args == ()
+            assert kwargs == {
+                "cell_id": client[idx]["id"],
+                "prompt_id": "12345",
+                "prompt": "Once upon a time",
+                "username": None,
+                "timestamp": None,
+            }
 
 
 async def test_set_cell_with_user_prompt(ws_server):
     room = uuid.uuid4().hex
     room_url = f"{ws_server}/{room}"
-    with NbModelClient(room_url) as client:
-        with BaseNbAgent(room_url) as agent:
+    async with NbModelClient(room_url) as client:
+        async with BaseNbAgent(room_url) as agent:
             agent._on_user_prompt = MagicMock()
             client.add_code_cell(
                 "print('hello')",
@@ -98,5 +105,11 @@ async def test_set_cell_with_user_prompt(ws_server):
 
             assert agent._on_user_prompt.called
             args, kwargs = agent._on_user_prompt.call_args
-            assert args == (client[0]["id"], "Once upon a time")
-            assert kwargs == {}
+            assert args == ()
+            assert kwargs == {
+                "cell_id": client[0]["id"],
+                "prompt_id": "12345",
+                "prompt": "Once upon a time",
+                "username": None,
+                "timestamp": None,
+            }

--- a/jupyter_nbmodel_client/tests/test_client.py
+++ b/jupyter_nbmodel_client/tests/test_client.py
@@ -5,13 +5,13 @@
 from jupyter_nbmodel_client import NbModelClient, get_jupyter_notebook_websocket_url
 
 
-def test_create_notebook_context_manager(jupyter_server, notebook_factory):
+async def test_create_notebook_context_manager(jupyter_server, notebook_factory):
     server_url, token = jupyter_server
     path = "test.ipynb"
 
     notebook_factory(path)
 
-    with NbModelClient(
+    async with NbModelClient(
         get_jupyter_notebook_websocket_url(server_url=server_url, path=path, token=token)
     ) as notebook:
         dumped = notebook.as_dict()
@@ -44,7 +44,7 @@ def test_create_notebook_context_manager(jupyter_server, notebook_factory):
     }
 
 
-def test_create_notebook_no_context_manager(jupyter_server, notebook_factory):
+async def test_create_notebook_no_context_manager(jupyter_server, notebook_factory):
     server_url, token = jupyter_server
     path = "test.ipynb"
 
@@ -53,11 +53,11 @@ def test_create_notebook_no_context_manager(jupyter_server, notebook_factory):
     notebook = NbModelClient(
         get_jupyter_notebook_websocket_url(server_url=server_url, path=path, token=token)
     )
-    notebook.start()
+    await notebook.start()
     try:
         dumped = notebook.as_dict()
     finally:
-        notebook.stop()
+        await notebook.stop()
 
     assert isinstance(dumped["cells"][0]["id"], str)
     del dumped["cells"][0]["id"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ classifiers = [
 dependencies = [
   "jupyter_ydoc>=2.1.2,<4.0.0",
   "nbformat~=5.0",
-  # "pycrdt >=0.10.3,<0.13.0",
-  "pycrdt @ git+https://github.com/fcollonval/pycrdt.git@dev",
+  "pycrdt >=0.10.3,<0.13.0",
+  # "pycrdt @ git+https://github.com/fcollonval/pycrdt.git@dev",
   "requests",
   "websockets>=14.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,14 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Framework :: Jupyter",
 ]
-dependencies = ["jupyter_ydoc>=2.1.2,<4.0.0", "nbformat~=5.0", "pycrdt >=0.10.3,<0.13.0", "requests", "websockets>=14.0.0"]
+dependencies = [
+  "jupyter_ydoc>=2.1.2,<4.0.0",
+  "nbformat~=5.0",
+  # "pycrdt >=0.10.3,<0.13.0",
+  "pycrdt @ git+https://github.com/fcollonval/pycrdt.git@dev",
+  "requests",
+  "websockets>=14.0.0"
+]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Framework :: Jupyter",
 ]
-dependencies = ["jupyter_ydoc>=2.1.2,<4.0.0", "nbformat~=5.0", "pycrdt >=0.10.3,<0.11.0", "requests", "websocket-client"]
+dependencies = ["jupyter_ydoc>=2.1.2,<4.0.0", "nbformat~=5.0", "pycrdt >=0.10.3,<0.11.0", "requests", "websockets>=14.0.0"]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ file = "LICENSE"
 [project.urls]
 Home = "https://github.com/datalayer/jupyter-nbmodel-client"
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.version]
 path = "jupyter_nbmodel_client/__init__.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Framework :: Jupyter",
 ]
-dependencies = ["jupyter_ydoc>=2.1.2,<4.0.0", "nbformat~=5.0", "pycrdt >=0.10.3,<0.11.0", "requests", "websockets>=14.0.0"]
+dependencies = ["jupyter_ydoc>=2.1.2,<4.0.0", "nbformat~=5.0", "pycrdt >=0.10.3,<0.13.0", "requests", "websockets>=14.0.0"]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
The foundation of jupyter ydoc is built on top of pycrdt a thin wrapper of [Yrs](https://github.com/y-crdt/y-crdt). Unfortunately that library is not [thread safe](https://github.com/y-crdt/y-octo/blob/main/y-octo-utils/yrs-is-unsafe/README.md). Therefore when implementing the logic for an agent reacting to document changes, we were facing lost of critical runtime error because the changes and the callback are not necessarily implemented in the same thread.

> basically the document was exchanging with the peers through a websocket in a thread when the document itself and the callback on changes were handle in the main thread.

The best workaround while keeping Yrs is to move to an async approach to fake multi-threading. Hence this PR.