### PR TITLE
feat: support additional WebSocket handshake headers

### DIFF
--- a/jupyter_nbmodel_client/client.py
+++ b/jupyter_nbmodel_client/client.py
@@ -118,6 +118,9 @@ class NbModelClient(NotebookModel):
         log: [optional] Custom logger; default local logger
         ws_max_body_size: [optional] Maximum WebSocket body size in bytes; default 16MB
         close_timeout: [optional] Timeout for propagating final changes on close; default to timeout value
+        additional_headers: [optional] Extra HTTP headers to send during the WebSocket
+            handshake, e.g. ``Cookie`` and ``X-XSRFToken`` for cookie/XSRF-protected
+            Jupyter servers; default None
 
     Examples:
 
@@ -161,6 +164,7 @@ class NbModelClient(NotebookModel):
         log: logging.Logger | None = None,
         ws_max_body_size: int | None = None,
         close_timeout: float | None = None,
+        additional_headers: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
         self._ws_url = websocket_url
@@ -170,6 +174,7 @@ class NbModelClient(NotebookModel):
         self._log = log or DEFAULT_LOGGER
         self._ws_max_body_size = ws_max_body_size or WEBSOCKETS_MAX_BODY_SIZE
         self._close_timeout = close_timeout if close_timeout is not None else timeout
+        self._additional_headers = additional_headers
 
         self.__synced = asyncio.Event()
         self.__run: asyncio.Task | None = None
@@ -225,6 +230,7 @@ class NbModelClient(NotebookModel):
             user_agent_header="Jupyter NbModel Client",
             logger=self._log,
             max_size=self._ws_max_body_size,
+            additional_headers=self._additional_headers,
         )
         messages_queue: asyncio.Queue[bytes] = asyncio.Queue()
 

--- a/jupyter_nbmodel_client/helpers.py
+++ b/jupyter_nbmodel_client/helpers.py
@@ -18,6 +18,7 @@ def get_notebook_websocket_url(
     token: str | None = None,
     timeout: float = REQUEST_TIMEOUT,
     log: logging.Logger | None = None,
+    headers: dict[str, str] | None = None,
 ) -> str:
     """Get the websocket endpoint to connect to a collaborative Jupyter notebook.
 
@@ -28,17 +29,19 @@ def get_notebook_websocket_url(
         token: [optional] Jupyter Server authentication token; default None
         timeout: [optional] Request timeout in seconds; default to environment variable REQUEST_TIMEOUT
         log: [optional] Custom logger; default local logger
+        headers: [optional] Extra HTTP headers for the session request, e.g. Cookie and
+            X-XSRFToken for cookie/XSRF-protected servers; default None
 
     Returns:
         The websocket endpoint
     """
     if provider == "jupyter":
         return get_jupyter_notebook_websocket_url(
-            server_url, path, token, timeout, log
+            server_url, path, token, timeout, log, headers
         )
     elif provider == "datalayer":
         return get_datalayer_notebook_websocket_url(
-            server_url, path, token, timeout, log
+            server_url, path, token, timeout, log, headers
         )
 
 
@@ -48,6 +51,7 @@ def get_jupyter_notebook_websocket_url(
     token: str | None = None,
     timeout: float = REQUEST_TIMEOUT,
     log: logging.Logger | None = None,
+    headers: dict[str, str] | None = None,
 ) -> str:
     """Get the websocket endpoint to connect to a collaborative Jupyter notebook.
 
@@ -57,6 +61,8 @@ def get_jupyter_notebook_websocket_url(
         token: [optional] Jupyter Server authentication token; default None
         timeout: [optional] Request timeout in seconds; default to environment variable REQUEST_TIMEOUT
         log: [optional] Custom logger; default local logger
+        headers: [optional] Extra HTTP headers for the session request, e.g. Cookie and
+            X-XSRFToken for cookie/XSRF-protected servers; default None
 
     Returns:
         The websocket endpoint
@@ -69,6 +75,7 @@ def get_jupyter_notebook_websocket_url(
         method="PUT",
         json={"format": "json", "type": "notebook"},
         timeout=timeout,
+        headers=headers,
     )
 
     response.raise_for_status()
@@ -91,6 +98,7 @@ def get_datalayer_notebook_websocket_url(
     token: str | None = None,
     timeout: float = REQUEST_TIMEOUT,
     log: logging.Logger | None = None,
+    headers: dict[str, str] | None = None,
 ) -> str:
     """Get the websocket endpoint to connect to a collaborative notebook
     on Datalayer spacer.
@@ -101,6 +109,8 @@ def get_datalayer_notebook_websocket_url(
         token: [optional] Datalayer Server JWT authentication token; default None
         timeout: [optional] Request timeout in seconds; default to environment variable REQUEST_TIMEOUT
         log: [optional] Custom logger; default local logger
+        headers: [optional] Extra HTTP headers for the session request, e.g. Cookie and
+            X-XSRFToken for cookie/XSRF-protected servers; default None
 
     Returns:
         The websocket endpoint
@@ -113,6 +123,7 @@ def get_datalayer_notebook_websocket_url(
         token,
         method="GET",
         timeout=timeout,
+        headers=headers,
     )
 
     response.raise_for_status()

--- a/jupyter_nbmodel_client/tests/test_client.py
+++ b/jupyter_nbmodel_client/tests/test_client.py
@@ -2,7 +2,64 @@
 #
 # BSD 3-Clause License
 
+import jupyter_nbmodel_client.client as nbmodel_client_module
 from jupyter_nbmodel_client import NbModelClient, get_jupyter_notebook_websocket_url
+
+
+async def test_additional_headers__forwarded_to_websocket_connect(
+    jupyter_server, notebook_factory, monkeypatch
+):
+    """Headers passed to NbModelClient are forwarded to the websocket handshake.
+
+    This is what lets callers authenticate cookie/XSRF-protected Jupyter servers
+    without monkey-patching the module-level ``connect`` function.
+    """
+    server_url, token = jupyter_server
+    path = "test_headers.ipynb"
+
+    notebook_factory(path)
+
+    forwarded_headers: list[dict[str, str] | None] = []
+    real_connect = nbmodel_client_module.connect
+
+    async def capturing_connect(*args, **kwargs):
+        forwarded_headers.append(kwargs.get("additional_headers"))
+        return await real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(nbmodel_client_module, "connect", capturing_connect)
+
+    additional_headers = {"X-Test-Header": "nbmodel"}
+    async with NbModelClient(
+        get_jupyter_notebook_websocket_url(server_url=server_url, path=path, token=token),
+        additional_headers=additional_headers,
+    ) as notebook:
+        assert notebook.synced
+
+    assert forwarded_headers == [additional_headers]
+
+
+async def test_additional_headers__defaults_to_none(jupyter_server, notebook_factory, monkeypatch):
+    """When no headers are provided, None is forwarded (unchanged default behaviour)."""
+    server_url, token = jupyter_server
+    path = "test_no_headers.ipynb"
+
+    notebook_factory(path)
+
+    forwarded_headers: list[dict[str, str] | None] = []
+    real_connect = nbmodel_client_module.connect
+
+    async def capturing_connect(*args, **kwargs):
+        forwarded_headers.append(kwargs.get("additional_headers"))
+        return await real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(nbmodel_client_module, "connect", capturing_connect)
+
+    async with NbModelClient(
+        get_jupyter_notebook_websocket_url(server_url=server_url, path=path, token=token)
+    ) as notebook:
+        assert notebook.synced
+
+    assert forwarded_headers == [None]
 
 
 async def test_create_notebook_context_manager(jupyter_server, notebook_factory):

--- a/jupyter_nbmodel_client/tests/test_helpers.py
+++ b/jupyter_nbmodel_client/tests/test_helpers.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023-2024 Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+import jupyter_nbmodel_client.helpers as helpers_module
+import jupyter_nbmodel_client.utils as utils_module
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self):
+        ...
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch__merges_custom_headers_over_defaults(monkeypatch):
+    captured_headers = {}
+
+    def fake_put(request, headers=None, **kwargs):
+        captured_headers.update(headers)
+        return _FakeResponse({})
+
+    monkeypatch.setattr(utils_module.requests, "put", fake_put)
+
+    utils_module.fetch(
+        "http://localhost/api",
+        token="secret-token",
+        method="PUT",
+        headers={"Cookie": "session=abc", "Accept": "text/plain"},
+    )
+
+    # Caller header overrides the default Accept, extra headers are added,
+    # and the remaining defaults plus the token are preserved.
+    assert captured_headers["Accept"] == "text/plain"
+    assert captured_headers["Cookie"] == "session=abc"
+    assert captured_headers["Content-Type"] == "application/json"
+    assert captured_headers["Authorization"] == "Bearer secret-token"
+
+
+def test_get_jupyter_notebook_websocket_url__forwards_headers(monkeypatch):
+    captured = {}
+
+    def fake_fetch(request, token=None, **kwargs):
+        captured["headers"] = kwargs.get("headers")
+        captured["token"] = token
+        return _FakeResponse(
+            {
+                "format": "json",
+                "type": "notebook",
+                "fileId": "file-id",
+                "sessionId": "session-id",
+            }
+        )
+
+    monkeypatch.setattr(helpers_module, "fetch", fake_fetch)
+
+    room_url = helpers_module.get_jupyter_notebook_websocket_url(
+        "http://localhost:8888",
+        "notebook.ipynb",
+        headers={"Cookie": "session=abc", "X-XSRFToken": "xsrf"},
+    )
+
+    assert captured["headers"] == {"Cookie": "session=abc", "X-XSRFToken": "xsrf"}
+    assert room_url.startswith("ws://localhost:8888/api/collaboration/room/")
+    assert "sessionId=session-id" in room_url

--- a/jupyter_nbmodel_client/utils.py
+++ b/jupyter_nbmodel_client/utils.py
@@ -38,13 +38,15 @@ def fetch(
     """Fetch a network resource as a context manager."""
     method = kwargs.pop("method", "GET")
     f = getattr(requests, method.lower())
-    headers = kwargs.pop("headers", {})
-    if len(headers) == 0:
-        headers = {
-            "Accept": "application/json",
-            "Content-Type": "application/json",
-            "User-Agent": "Jupyter Nbmodel Client",
-        }
+    # Start from the JSON defaults and let caller-supplied headers override them, so extra
+    # headers (e.g. Cookie/X-XSRFToken for cookie-protected servers) can be added without
+    # dropping the defaults.
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "Jupyter Nbmodel Client",
+    }
+    headers.update(kwargs.pop("headers", None) or {})
     if token:
         headers["Authorization"] = f"Bearer {token}"
     if "timeout" not in kwargs:


### PR DESCRIPTION
## Summary

`NbModelClient` could previously only authenticate via a token embedded in the WebSocket URL. There was no way to send extra HTTP headers (e.g. `Cookie` / `X-XSRFToken`) during the WebSocket handshake.

As a result, downstream projects connecting to **cookie/XSRF-protected Jupyter servers** had to monkey-patch the module-level `connect` function to inject a `Cookie` header — see the workaround in [`jupyter-mcp-server#250`](https://github.com/datalayer/jupyter-mcp-server/pull/250), which notes it is **not concurrency-safe** (concurrent connections race on the module-level mutation).

This PR removes the need for that monkey-patch.

## Changes

- **`NbModelClient(..., additional_headers=...)`** — a new optional parameter, forwarded verbatim to `websockets.connect(..., additional_headers=...)` (a native kwarg of `websockets`, which is already a dependency). Defaults to `None`, so existing behaviour is unchanged.
- **`get_notebook_websocket_url` / `get_jupyter_notebook_websocket_url` / `get_datalayer_notebook_websocket_url(..., headers=...)`** — a matching optional `headers` parameter, forwarded to the session-id request. This lets the same auth headers reach the `PUT /api/collaboration/session` call, so callers no longer need to re-implement those helpers either.
- **`utils.fetch`** now merges caller-supplied headers over the JSON defaults instead of dropping the defaults when any header is passed. Token-based `Authorization` is still applied on top.

All new parameters default to `None`; token-based connections are fully backward compatible.

### Downstream effect

The `jupyter-mcp-server` workaround collapses from a module-level monkey-patch to:

```python
self._notebook = NbModelClient(ws_url, additional_headers={"Cookie": cookie_header})
await self._notebook.__aenter__()
```

## Test plan

- [x] `pytest jupyter_nbmodel_client/tests/` — 19 passed
- Added `test_additional_headers__forwarded_to_websocket_connect` and `test_additional_headers__defaults_to_none` (real Jupyter server fixture, verify the headers reach the handshake)
- Added `test_helpers.py`: `test_fetch__merges_custom_headers_over_defaults` and `test_get_jupyter_notebook_websocket_url__forwards_headers`