### PR TITLE
fix: do not save transient information in the document

### DIFF
--- a/jupyter_nbmodel_client/model.py
+++ b/jupyter_nbmodel_client/model.py
@@ -90,6 +90,23 @@ class KernelClient(t.Protocol):
         ...
 
 
+def _persistable_output(output: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Copy an output without the kernel protocol fields absent from the nbformat schema.
+
+    ``transient`` is part of the kernel messaging protocol, not of the notebook format; see
+    https://jupyter-client.readthedocs.io/en/stable/messaging.html#display-data. It must be
+    kept in ``outputs`` for ``update_display_data`` matching, but a document may only contain
+    schema-valid outputs.
+
+    Args:
+        output: The output to copy
+
+    Returns:
+        The output without its transient information
+    """
+    return {key: value for key, value in output.items() if key != "transient"}
+
+
 def save_in_notebook_hook(
     lock: threading.Lock, outputs: list[dict], ycell: pycrdt.Map, origin: int, msg: dict
 ) -> None:
@@ -107,15 +124,15 @@ def save_in_notebook_hook(
         with lock:
             with cell_outputs.doc.transaction(origin=origin):
                 cell_outputs.clear()
-                cell_outputs.extend(outputs)
+                cell_outputs.extend(map(_persistable_output, outputs))
     else:
         with lock:
             with cell_outputs.doc.transaction(origin=origin):
                 for index in indexes:
                     if index >= len(cell_outputs):
-                        cell_outputs.append(outputs[index])
+                        cell_outputs.append(_persistable_output(outputs[index]))
                     else:
-                        cell_outputs[index] = outputs[index]
+                        cell_outputs[index] = _persistable_output(outputs[index])
 
 
 class NotebookModel(MutableSequence):

--- a/jupyter_nbmodel_client/tests/test_model.py
+++ b/jupyter_nbmodel_client/tests/test_model.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023-2024 Datalayer, Inc.
+#
+# BSD 3-Clause License
+
+import threading
+
+import nbformat
+import pytest
+from jupyter_ydoc import YNotebook
+
+from jupyter_nbmodel_client.model import save_in_notebook_hook
+
+# Without jupyter_kernel_client, model.py falls back to an output hook built on
+# ``nbformat.output_from_msg``, which never emits transient information.
+pytest.importorskip("jupyter_kernel_client")
+
+
+def _new_ycell():
+    ydoc = YNotebook()
+    ydoc.set(nbformat.v4.new_notebook(cells=[nbformat.v4.new_code_cell("display(obj)")]))
+    return ydoc, ydoc.ycells[0]
+
+
+def _display_msg(value, display_id=None, msg_type="display_data"):
+    content = {"data": {"text/plain": value}, "metadata": {}}
+    if display_id is not None:
+        content["transient"] = {"display_id": display_id}
+    return {"header": {"msg_type": msg_type}, "content": content}
+
+
+@pytest.mark.parametrize("display_id", ["abc123", None])
+def test_save_in_notebook_hook__does_not_save_transient(display_id):
+    """Transient information is kernel protocol; the document must stay nbformat valid."""
+    ydoc, ycell = _new_ycell()
+    outputs: list[dict] = []
+
+    save_in_notebook_hook(threading.Lock(), outputs, ycell, 0, _display_msg("v1", display_id))
+
+    document = ydoc.get()
+    assert "transient" not in document["cells"][0]["outputs"][0]
+    nbformat.validate(nbformat.from_dict(document))
+    # The kernel client still reads it back for update_display_data matching.
+    assert "transient" in outputs[0]
+
+
+def test_save_in_notebook_hook__update_display_data_updates_output_in_place():
+    """Keeping transient out of the document must not break display_id matching."""
+    ydoc, ycell = _new_ycell()
+    outputs: list[dict] = []
+
+    save_in_notebook_hook(threading.Lock(), outputs, ycell, 0, _display_msg("v1", "abc123"))
+    save_in_notebook_hook(
+        threading.Lock(), outputs, ycell, 0, _display_msg("v2", "abc123", "update_display_data")
+    )
+
+    saved_outputs = ydoc.get()["cells"][0]["outputs"]
+    assert len(saved_outputs) == 1
+    assert saved_outputs[0]["data"] == {"text/plain": "v2"}


### PR DESCRIPTION
## Problem

`save_in_notebook_hook` writes the kernel outputs into the shared document verbatim. For `display_data`, `jupyter_kernel_client.client.output_hook` puts the kernel protocol's `transient` field into the output ([client.py#L74](https://github.com/datalayer/jupyter-kernel-client/blob/2dd9bd83/jupyter_kernel_client/client.py#L74)), and `transient` is not part of the nbformat schema. With RTC the document is autosaved as it stands, so the saved `.ipynb` stops validating:

```
nbformat.validator.NotebookValidationError: Additional properties are not allowed ('transient' was unexpected)
```

`KernelClient.execute()` does clean `transient` ([client.py#L301-L305](https://github.com/datalayer/jupyter-kernel-client/blob/2dd9bd83/jupyter_kernel_client/client.py#L301-L305)), but only from its own return value and only once the execution is over. pycrdt copies each dict at write time, so that later `del` mutates the local dict and never reaches the copy already in the document.

Reported downstream as datalayer/jupyter-mcp-server#263 (the second of the two defects described there).

One detail that widens the scope: `output_hook` uses `content.get("transient")`, so the key is written even when the kernel message carries no transient at all, as `"transient": None`. Every `display_data` output saved through this path is affected, not only the ones carrying a `display_id`.

## Invariant

Anything written into the document must be nbformat valid, because that document is what gets saved as the notebook. `transient` is kernel messaging protocol rather than notebook content: it may live in the in-process `outputs` list, but never in the document.

## Fix

Write a sanitized copy into the ycell, and leave `outputs` alone.

Leaving `outputs` intact is required rather than incidental: `output_hook` reads `display_id` back out of that list to match a later `update_display_data` ([client.py#L89-L96](https://github.com/datalayer/jupyter-kernel-client/blob/2dd9bd83/jupyter_kernel_client/client.py#L89-L96)). I ran that counterfactual against `jupyter_kernel_client` directly: with `transient` stripped from `outputs`, the `update_display_data` message matches nothing, `output_hook` returns an empty index set, and the update is silently dropped, leaving the cell showing the stale value. So the same fix applied one layer up, in `output_hook` itself, would trade this bug for a worse one.

## How I verified

Python 3.12 container, this branch installed with `pip install -e .`, `jupyter-kernel-client` at `2dd9bd83`. I printed `module.__file__` and its sha256 for both packages so the runs are against these sources rather than an installed wheel.

The new tests in `jupyter_nbmodel_client/tests/test_model.py`:

- against this branch: 3 passed
- against `main`'s `model.py`, with the fix reverted and the tests kept: 2 failed on `assert "transient" not in ...`, showing `{'output_type': 'display_data', ..., 'transient': None}`

The third test (`update_display_data` updates the output in place) passes both before and after this change, which is its purpose: it guards the matching behaviour described above.

Separately from the tests, I drove `save_in_notebook_hook` with an ipykernel-shaped `display_data` message and ran `nbformat.validate` on `YNotebook.get()`, which is what RTC persists. It fails on `main` with the error quoted above and passes with this change.

`pytest jupyter_nbmodel_client/tests/test_model.py jupyter_nbmodel_client/tests/test_helpers.py`: 5 passed.

## What I did not verify

- Defect 1 of datalayer/jupyter-mcp-server#263 (executing a cell drops `execution_count` from every code cell) is not addressed here and I could not reproduce it: it needs a live server with RTC. A notebook hit by that defect stays invalid on `execution_count` regardless of this change, so this PR fixes only the `transient` half of that report.
- Nothing here ran against a live JupyterLab or a real RTC session. I drove the hook and the document directly, in process.
- I did not get `tests/test_client.py` to run: those tests start a real `jupyter-server` subprocess, which never became reachable in my container. They error the same way on unmodified `main`, so this is my environment and not the change, but it does mean I am relying on CI for that part of the suite.
- I did not run the linters as configured: `pre-commit` reformats `model.py` wholesale on current `main` as well, so I kept the diff to the fix. `ruff check jupyter_nbmodel_client/model.py` reports the same 33 findings before and after my change, and the new test file is clean.

## Note

This change was written with AI assistance. The root cause, the runs and the tests are mine and I checked them. The repository does not state a policy on this, so I am mentioning it.
